### PR TITLE
プラグイン名を一般的な形式に変更

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export default function cdn({
       : pattern;
 
   return {
-    name: "vite-cdn",
+    name: "vite:cdn",
     enforce: "pre",
     async resolveId(name) {
       const pkgName = name.match(


### PR DESCRIPTION
Viteに渡されるプラグインの名前を変更します。

参考
https://github.com/richardtallent/vite-plugin-singlefile/blob/70f812aae821bb09ab6abcc4ff7a1dcb5f31c05b/src/index.ts
https://github.com/vbenjs/vite-plugin-html/blob/a21ec7f4971312cc75ef3d7113b6d86e93dbfeac/packages/core/src/htmlPlugin.ts
